### PR TITLE
Use pgrep to determine if rabbitmq_server is actually running.

### DIFF
--- a/rabbitmq-connections
+++ b/rabbitmq-connections
@@ -20,7 +20,7 @@
 # always be included.
 
 if [ "$1" = "autoconf" ]; then
-	echo yes
+	pgrep -f rabbitmq_server >/dev/null && echo yes || echo no
 	exit 0
 fi
 

--- a/rabbitmq-consumers
+++ b/rabbitmq-consumers
@@ -21,7 +21,7 @@
 # always be included.
 
 if [ "$1" = "autoconf" ]; then
-	echo yes
+	pgrep -f rabbitmq_server >/dev/null && echo yes || echo no
 	exit 0
 fi
 

--- a/rabbitmq-messages
+++ b/rabbitmq-messages
@@ -21,7 +21,7 @@
 # always be included.
 
 if [ "$1" = "autoconf" ]; then
-	echo yes
+	pgrep -f rabbitmq_server >/dev/null && echo yes || echo no
 	exit 0
 fi
 

--- a/rabbitmq-messages_unacknowledged
+++ b/rabbitmq-messages_unacknowledged
@@ -21,7 +21,7 @@
 # always be included.
 
 if [ "$1" = "autoconf" ]; then
-	echo yes
+	pgrep -f rabbitmq_server >/dev/null && echo yes || echo no
 	exit 0
 fi
 

--- a/rabbitmq-messages_uncommitted
+++ b/rabbitmq-messages_uncommitted
@@ -21,7 +21,7 @@
 # always be included.
 
 if [ "$1" = "autoconf" ]; then
-	echo yes
+	pgrep -f rabbitmq_server >/dev/null && echo yes || echo no
 	exit 0
 fi
 

--- a/rabbitmq-queue_memory
+++ b/rabbitmq-queue_memory
@@ -21,7 +21,7 @@
 # always be included.
 
 if [ "$1" = "autoconf" ]; then
-	echo yes
+	pgrep -f rabbitmq_server >/dev/null && echo yes || echo no
 	exit 0
 fi
 


### PR DESCRIPTION
Currently, if run with munin's `autoconf` thingey, these plugins always think they should be installed. I've modified them to check whether `rabbitmq_server` is actually in the processlist instead.

A more portable solution might pipe `ps auxww` to `grep`. Maybe I should do that instead....
