### PR TITLE
Adds a HOME env. variable when calling to rabbitmqctl

### DIFF
--- a/rabbitmq-connections
+++ b/rabbitmq-connections
@@ -24,6 +24,8 @@ if [ "$1" = "autoconf" ]; then
 	exit 0
 fi
 
+HOME=/tmp/
+
 # If run with the "config"-parameter, give out information on how the
 # graphs should look. 
 
@@ -61,4 +63,4 @@ fi
 # real work - i.e. display the data. Almost always this will be
 # "value" subfield for every data field.
 
-echo "connections.value $(rabbitmqctl list_connections | grep -v "^Listing" | grep -v "done.$" | wc -l)"
+echo "connections.value $(HOME=$HOME rabbitmqctl list_connections | grep -v "^Listing" | grep -v "done.$" | wc -l)"

--- a/rabbitmq-consumers
+++ b/rabbitmq-consumers
@@ -28,8 +28,9 @@ fi
 # If run with the "config"-parameter, give out information on how the
 # graphs should look. 
 
+HOME=/tmp/
 VHOST=${vhost:-"/"}
-QUEUES=$(rabbitmqctl list_queues -p $VHOST name | \
+QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
 		grep -v '^Listing' | \
 		grep -v 'done\.$' | sed -e 's/[.-=]/_/g' )
  
@@ -69,6 +70,6 @@ fi
 # real work - i.e. display the data. Almost always this will be
 # "value" subfield for every data field.
 
-rabbitmqctl list_queues -p $VHOST name consumers| \
+HOME=$HOME rabbitmqctl list_queues -p $VHOST name consumers| \
 	grep -v "^Listing" | grep -v "done.$" | \
     perl -nle'($q, $s) = split; $q =~ s/[.-=]/_/g; print("$q.value $s")'

--- a/rabbitmq-messages
+++ b/rabbitmq-messages
@@ -28,8 +28,9 @@ fi
 # If run with the "config"-parameter, give out information on how the
 # graphs should look. 
 
+HOME=/tmp/
 VHOST=${vhost:-"/"}
-QUEUES=$(rabbitmqctl list_queues -p $VHOST name | \
+QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
 		grep -v '^Listing' | \
 		grep -v 'done\.$' | sed -e 's/[.-=]/_/g' )
  
@@ -69,6 +70,6 @@ fi
 # real work - i.e. display the data. Almost always this will be
 # "value" subfield for every data field.
 
-rabbitmqctl list_queues -p $VHOST | \
+HOME=$HOME rabbitmqctl list_queues -p $VHOST | \
 	grep -v "^Listing" | grep -v "done.$" | \
 	perl -nle'($q, $s) = split; $q =~ s/[.-=]/_/g; print("$q.value $s")'

--- a/rabbitmq-messages_unacknowledged
+++ b/rabbitmq-messages_unacknowledged
@@ -28,8 +28,9 @@ fi
 # If run with the "config"-parameter, give out information on how the
 # graphs should look. 
 
+HOME=/tmp/
 VHOST=${vhost:-"/"}
-QUEUES=$(rabbitmqctl list_queues -p $VHOST name | \
+QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
 		grep -v '^Listing' | \
 		grep -v 'done\.$' | sed -e 's/[.-=]/_/g' )
  
@@ -69,6 +70,6 @@ fi
 # real work - i.e. display the data. Almost always this will be
 # "value" subfield for every data field.
 
-rabbitmqctl list_queues -p $VHOST name messages_unacknowledged | \
+HOME=$HOME rabbitmqctl list_queues -p $VHOST name messages_unacknowledged | \
 	grep -v "^Listing" | grep -v "done.$" | \
     perl -nle'($q, $s) = split; $q =~ s/[.-=]/_/g; print("$q.value $s")'

--- a/rabbitmq-messages_uncommitted
+++ b/rabbitmq-messages_uncommitted
@@ -28,8 +28,9 @@ fi
 # If run with the "config"-parameter, give out information on how the
 # graphs should look. 
 
+HOME=/tmp/
 VHOST=${vhost:-"/"}
-QUEUES=$(rabbitmqctl list_queues -p $VHOST name | \
+QUEUES=$(HOME=$HOME rabbitmqctl list_queues -p $VHOST name | \
 		grep -v '^Listing' | \
 		grep -v 'done\.$' | sed -e 's/[.-=]/_/g' )
  
@@ -69,6 +70,6 @@ fi
 # real work - i.e. display the data. Almost always this will be
 # "value" subfield for every data field.
 
-rabbitmqctl list_queues -p $VHOST name messages_uncommitted | \
+HOME=$HOME rabbitmqctl list_queues -p $VHOST name messages_uncommitted | \
 	grep -v "^Listing" | grep -v "done.$" | \
     perl -nle'($q, $s) = split; $q =~ s/[.-=]/_/g; print("$q.value $s")'

--- a/rabbitmq-queue_memory
+++ b/rabbitmq-queue_memory
@@ -28,6 +28,7 @@ fi
 # If run with the "config"-parameter, give out information on how the
 # graphs should look. 
 
+HOME=/tmp/
 VHOST=${vhost:-"/"}
 QUEUES=$(rabbitmqctl list_queues -p $VHOST name | \
 		grep -v '^Listing' | \
@@ -69,6 +70,6 @@ fi
 # real work - i.e. display the data. Almost always this will be
 # "value" subfield for every data field.
 
-rabbitmqctl list_queues -p $VHOST name memory | \
+HOME=$HOME rabbitmqctl list_queues -p $VHOST name memory | \
 	grep -v "^Listing" | grep -v "done.$" | \
     perl -nle'($q, $s) = split; $q =~ s/[.-=]/_/g; print("$q.value $s")'


### PR DESCRIPTION
I had to give a $HOME to my rabbitmqctl processes. I read that Erlang needs a $HOME to be able to run.
