### PR TITLE
RabbitMQ 3.1 does not support -p arg for list_channels

### DIFF
--- a/rabbitmq_messages_uncommitted
+++ b/rabbitmq_messages_uncommitted
@@ -70,4 +70,4 @@ fi
 # real work - i.e. display the data. Almost always this will be
 # "value" subfield for every data field.
 
-HOME=$HOME rabbitmqctl list_channels -p $VHOST name messages_uncommitted | grep -v "^Listing" | grep -v "done.$" | sed "s/[\t]/.value /g"
+HOME=$HOME rabbitmqctl list_channels name vhost messages_uncommitted | grep -v "\.\.\." | grep $VHOST | sed "s/[ ]->.*[\t]/.value /g"


### PR DESCRIPTION
Plugin failed for me, but this morning I noticed the error logs to find that newer RabbitMQ 3.1 does not support -p. So, we list channels with vhosts and grep for our $VHOST and apply sed to do the magic :)

Signed-off-by: Rohit Yadav rohit.yadav@wingify.com
